### PR TITLE
Translate admin pages to English

### DIFF
--- a/MiAppAspire.Web/Components/Layout/NavMenu.razor
+++ b/MiAppAspire.Web/Components/Layout/NavMenu.razor
@@ -28,7 +28,7 @@
 
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="admin">
-                <span class="bi bi-list-nested" aria-hidden="true"></span> Administración
+                <span class="bi bi-list-nested" aria-hidden="true"></span> Administration
             </NavLink>
         </div>
     </nav>

--- a/MiAppAspire.Web/Components/Pages/Admin/Admin.razor
+++ b/MiAppAspire.Web/Components/Pages/Admin/Admin.razor
@@ -1,13 +1,13 @@
 @page "/admin"
 
-<PageTitle>Administración</PageTitle>
+<PageTitle>Administration</PageTitle>
 
-<h1>Menú de Administración</h1>
+<h1>Administration Menu</h1>
 
 <ul>
-    <li><NavLink href="/admin/solicitudes">Solicitudes</NavLink></li>
-    <li><NavLink href="/admin/mantenedores">Mantenedores</NavLink></li>
-    <li><NavLink href="/admin/usuarios">Usuarios</NavLink></li>
-    <li><NavLink href="/admin/reportes">Reportes</NavLink></li>
-    <li><NavLink href="/admin/configuraciones">Configuraciones</NavLink></li>
+    <li><NavLink href="/admin/requests">Requests</NavLink></li>
+    <li><NavLink href="/admin/maintainers">Maintainers</NavLink></li>
+    <li><NavLink href="/admin/users">Users</NavLink></li>
+    <li><NavLink href="/admin/reports">Reports</NavLink></li>
+    <li><NavLink href="/admin/settings">Settings</NavLink></li>
 </ul>

--- a/MiAppAspire.Web/Components/Pages/Admin/Configuraciones.razor
+++ b/MiAppAspire.Web/Components/Pages/Admin/Configuraciones.razor
@@ -1,6 +1,0 @@
-@page "/admin/configuraciones"
-@rendermode InteractiveServer
-
-<PageTitle>Configuraciones</PageTitle>
-
-<SimpleCrud Title="Configuraciones" />

--- a/MiAppAspire.Web/Components/Pages/Admin/Maintainers.razor
+++ b/MiAppAspire.Web/Components/Pages/Admin/Maintainers.razor
@@ -1,0 +1,6 @@
+@page "/admin/maintainers"
+@rendermode InteractiveServer
+
+<PageTitle>Maintainers</PageTitle>
+
+<SimpleCrud Title="Maintainers" />

--- a/MiAppAspire.Web/Components/Pages/Admin/Mantenedores.razor
+++ b/MiAppAspire.Web/Components/Pages/Admin/Mantenedores.razor
@@ -1,6 +1,0 @@
-@page "/admin/mantenedores"
-@rendermode InteractiveServer
-
-<PageTitle>Mantenedores</PageTitle>
-
-<SimpleCrud Title="Mantenedores" />

--- a/MiAppAspire.Web/Components/Pages/Admin/Reportes.razor
+++ b/MiAppAspire.Web/Components/Pages/Admin/Reportes.razor
@@ -1,6 +1,0 @@
-@page "/admin/reportes"
-@rendermode InteractiveServer
-
-<PageTitle>Reportes</PageTitle>
-
-<SimpleCrud Title="Reportes" />

--- a/MiAppAspire.Web/Components/Pages/Admin/Reports.razor
+++ b/MiAppAspire.Web/Components/Pages/Admin/Reports.razor
@@ -1,0 +1,6 @@
+@page "/admin/reports"
+@rendermode InteractiveServer
+
+<PageTitle>Reports</PageTitle>
+
+<SimpleCrud Title="Reports" />

--- a/MiAppAspire.Web/Components/Pages/Admin/Requests.razor
+++ b/MiAppAspire.Web/Components/Pages/Admin/Requests.razor
@@ -1,0 +1,6 @@
+@page "/admin/requests"
+@rendermode InteractiveServer
+
+<PageTitle>Requests</PageTitle>
+
+<SimpleCrud Title="Requests" />

--- a/MiAppAspire.Web/Components/Pages/Admin/Settings.razor
+++ b/MiAppAspire.Web/Components/Pages/Admin/Settings.razor
@@ -1,0 +1,6 @@
+@page "/admin/settings"
+@rendermode InteractiveServer
+
+<PageTitle>Settings</PageTitle>
+
+<SimpleCrud Title="Settings" />

--- a/MiAppAspire.Web/Components/Pages/Admin/Solicitudes.razor
+++ b/MiAppAspire.Web/Components/Pages/Admin/Solicitudes.razor
@@ -1,6 +1,0 @@
-@page "/admin/solicitudes"
-@rendermode InteractiveServer
-
-<PageTitle>Solicitudes</PageTitle>
-
-<SimpleCrud Title="Solicitudes" />

--- a/MiAppAspire.Web/Components/Pages/Admin/Users.razor
+++ b/MiAppAspire.Web/Components/Pages/Admin/Users.razor
@@ -1,0 +1,6 @@
+@page "/admin/users"
+@rendermode InteractiveServer
+
+<PageTitle>Users</PageTitle>
+
+<SimpleCrud Title="Users" />

--- a/MiAppAspire.Web/Components/Pages/Admin/Usuarios.razor
+++ b/MiAppAspire.Web/Components/Pages/Admin/Usuarios.razor
@@ -1,6 +1,0 @@
-@page "/admin/usuarios"
-@rendermode InteractiveServer
-
-<PageTitle>Usuarios</PageTitle>
-
-<SimpleCrud Title="Usuarios" />

--- a/MiAppAspire.Web/Components/SimpleCrud.razor
+++ b/MiAppAspire.Web/Components/SimpleCrud.razor
@@ -67,14 +67,14 @@
 
 <h3>@Title</h3>
 
-<button class="btn btn-primary mb-2" @onclick="BeginAdd">Nuevo</button>
+<button class="btn btn-primary mb-2" @onclick="BeginAdd">New</button>
 
 <table class="table">
     <thead>
         <tr>
             <th>ID</th>
-            <th>Nombre</th>
-            <th>Acciones</th>
+            <th>Name</th>
+            <th>Actions</th>
         </tr>
     </thead>
     <tbody>
@@ -95,13 +95,13 @@
                 <td>
                     @if (editId == item.Id)
                     {
-                        <button class="btn btn-sm btn-success" @onclick="() => SaveEdit(item.Id)">Guardar</button>
-                        <button class="btn btn-sm btn-secondary" @onclick="CancelEdit">Cancelar</button>
+                        <button class="btn btn-sm btn-success" @onclick="() => SaveEdit(item.Id)">Save</button>
+                        <button class="btn btn-sm btn-secondary" @onclick="CancelEdit">Cancel</button>
                     }
                     else
                     {
-                        <button class="btn btn-sm btn-primary" @onclick="() => Edit(item)">Editar</button>
-                        <button class="btn btn-sm btn-danger" @onclick="() => Delete(item.Id)">Eliminar</button>
+                        <button class="btn btn-sm btn-primary" @onclick="() => Edit(item)">Edit</button>
+                        <button class="btn btn-sm btn-danger" @onclick="() => Delete(item.Id)">Delete</button>
                     }
                 </td>
             </tr>
@@ -112,8 +112,8 @@
                 <td>--</td>
                 <td><input class="form-control" @bind="newName" /></td>
                 <td>
-                    <button class="btn btn-sm btn-success" @onclick="SaveNew">Guardar</button>
-                    <button class="btn btn-sm btn-secondary" @onclick="CancelAdd">Cancelar</button>
+                    <button class="btn btn-sm btn-success" @onclick="SaveNew">Save</button>
+                    <button class="btn btn-sm btn-secondary" @onclick="CancelAdd">Cancel</button>
                 </td>
             </tr>
         }


### PR DESCRIPTION
## Summary
- rename Spanish admin pages and their routes to English
- update navigation menu
- translate SimpleCrud component text
- translate admin menu items and titles

## Testing
- `dotnet build MiAppAspire.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616055ce84832dafcb316544f69be2