### PR TITLE
Add Pokémon list page

### DIFF
--- a/MiAppAspire.Web/Components/Layout/NavMenu.razor
+++ b/MiAppAspire.Web/Components/Layout/NavMenu.razor
@@ -31,5 +31,11 @@
                 <span class="bi bi-list-nested" aria-hidden="true"></span> Administration
             </NavLink>
         </div>
+
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="pokemons">
+                <span class="bi bi-collection-fill" aria-hidden="true"></span> Pokémon
+            </NavLink>
+        </div>
     </nav>
 </div>

--- a/MiAppAspire.Web/Components/Pages/Pokemons.razor
+++ b/MiAppAspire.Web/Components/Pages/Pokemons.razor
@@ -1,0 +1,85 @@
+@page "/pokemons"
+
+@inject PokemonApiClient PokeApi
+
+<PageTitle>Pokémon</PageTitle>
+
+<h1>Pokémon</h1>
+
+@if (loading)
+{
+    <p><em>Cargando...</em></p>
+}
+else if (pokemonPage?.Pokemon?.Length == 0)
+{
+    <p>No se encontraron resultados.</p>
+}
+else if (pokemonPage != null)
+{
+    <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4">
+        @foreach (var p in pokemonPage.Pokemon)
+        {
+            <div class="col">
+                <div class="card h-100 shadow-sm">
+                    <img src="@p.Sprites.FrontDefault" class="card-img-top" alt="@p.Name" />
+                    <div class="card-body">
+                        <h5 class="card-title text-capitalize">@p.Name</h5>
+                        <p class="card-text">
+                            @foreach (var t in p.Types)
+                            {
+                                <span class="badge bg-primary me-1 text-capitalize">@t.Type.Name</span>
+                            }
+                        </p>
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
+
+    <div class="d-flex justify-content-between align-items-center mt-3">
+        <button class="btn btn-secondary" @onclick="PrevPage" disabled="@(!HasPrev)">Anterior</button>
+        <span>Página @PageIndex</span>
+        <button class="btn btn-secondary" @onclick="NextPage" disabled="@(!HasNext)">Siguiente</button>
+    </div>
+}
+
+@code {
+    private int PageIndex = 1;
+    private const int PageSize = 12;
+    private (PokemonDetail[] Pokemon, int TotalCount)? pokemonPage;
+    private bool loading;
+
+    private bool HasPrev => PageIndex > 1;
+    private bool HasNext => pokemonPage?.TotalCount > PageIndex * PageSize;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadPage();
+    }
+
+    private async Task LoadPage()
+    {
+        loading = true;
+        StateHasChanged();
+        pokemonPage = await PokeApi.GetPokemonPageAsync((PageIndex - 1) * PageSize, PageSize);
+        loading = false;
+    }
+
+    private async Task PrevPage()
+    {
+        if (HasPrev)
+        {
+            PageIndex--;
+            await LoadPage();
+        }
+    }
+
+    private async Task NextPage()
+    {
+        if (HasNext)
+        {
+            PageIndex++;
+            await LoadPage();
+        }
+    }
+}

--- a/MiAppAspire.Web/Models/PokemonModels.cs
+++ b/MiAppAspire.Web/Models/PokemonModels.cs
@@ -1,0 +1,25 @@
+using System.Text.Json.Serialization;
+
+namespace MiAppAspire.Web.Models;
+
+public record PokemonListResponse(
+    int Count,
+    string? Next,
+    string? Previous,
+    [property: JsonPropertyName("results")] PokemonListItem[] Results);
+
+public record PokemonListItem(string Name, string Url);
+
+public record PokemonDetail(
+    string Name,
+    PokemonSprites Sprites,
+    PokemonTypeEntry[] Types);
+
+public record PokemonSprites(
+    [property: JsonPropertyName("front_default")] string? FrontDefault);
+
+public record PokemonTypeEntry(
+    int Slot,
+    NamedApiResource Type);
+
+public record NamedApiResource(string Name, string Url);

--- a/MiAppAspire.Web/PokemonApiClient.cs
+++ b/MiAppAspire.Web/PokemonApiClient.cs
@@ -1,0 +1,18 @@
+using MiAppAspire.Web.Models;
+
+namespace MiAppAspire.Web;
+
+public class PokemonApiClient(HttpClient httpClient)
+{
+    private readonly HttpClient _httpClient = httpClient;
+
+    public async Task<(PokemonDetail[] Pokemon, int TotalCount)> GetPokemonPageAsync(int offset, int limit, CancellationToken cancellationToken = default)
+    {
+        var list = await _httpClient.GetFromJsonAsync<PokemonListResponse>($"pokemon?offset={offset}&limit={limit}", cancellationToken)
+            ?? new PokemonListResponse(0, null, null, Array.Empty<PokemonListItem>());
+
+        var tasks = list.Results.Select(item => _httpClient.GetFromJsonAsync<PokemonDetail>(item.Url, cancellationToken));
+        var details = await Task.WhenAll(tasks);
+        return (details.Where(d => d != null).ToArray()!, list.Count);
+    }
+}

--- a/MiAppAspire.Web/Program.cs
+++ b/MiAppAspire.Web/Program.cs
@@ -18,6 +18,11 @@ builder.Services.AddHttpClient<WeatherApiClient>(client =>
         client.BaseAddress = new("https+http://apiservice");
     });
 
+builder.Services.AddHttpClient<PokemonApiClient>(client =>
+    {
+        client.BaseAddress = new("https://pokeapi.co/api/v2/");
+    });
+
 var app = builder.Build();
 
 if (!app.Environment.IsDevelopment())


### PR DESCRIPTION
## Summary
- fetch paginated Pokémon info from the public PokéAPI
- show Pokémon images and types in a modern card layout
- register a new `PokemonApiClient`
- add navigation entry for the new page

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d552f484832d8973acbeade88769